### PR TITLE
Fix Inter Variable typo

### DIFF
--- a/packages/client/src/App.css
+++ b/packages/client/src/App.css
@@ -8,7 +8,7 @@
 }
 
 * {
-  font-family: 'Inter Varable', Arial, Helvetica, sans-serif;
+  font-family: 'Inter Variable', Arial, Helvetica, sans-serif;
 }
 
 body {


### PR DESCRIPTION
## Summary
- fix typo in App.css so global `font-family` uses 'Inter Variable'

## Testing
- `git status --short`