### PR TITLE
Add S3 asset preloading

### DIFF
--- a/packages/client/src/components/Onboarding.tsx
+++ b/packages/client/src/components/Onboarding.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
+
 import onboardingImage1 from '../assets/frame1.png';
 import onboardingImage2 from '../assets/frame2.png';
+import { preloadAssets } from '../config/preloadAssets';
 
 type OnboardingProps = {
   onOnboardingComplete: () => void;
@@ -71,6 +73,7 @@ function Onboarding({ onOnboardingComplete }: OnboardingProps) {
   useEffect(() => {
     // Detect if user is on mobile
     setIsMobile(/iPhone|iPad|iPod|Android/i.test(navigator.userAgent));
+    preloadAssets();
   }, []);
 
   // Handle all touch/click events in one function

--- a/packages/client/src/config/preloadAssets.ts
+++ b/packages/client/src/config/preloadAssets.ts
@@ -1,0 +1,37 @@
+import { useGLTF } from '@react-three/drei';
+
+import { getModelUrl } from './assetPaths';
+
+const modelFiles: string[] = [
+  'full-maze-compressed.glb',
+  'object-w-compressed.glb',
+  'object-e-compressed.glb',
+  'object-n-compressed.glb',
+  'table-compressed.glb',
+  'sculpture-compressed.glb',
+];
+
+const videoUrls: string[] = [
+  'https://synergy-assets-11412.s3.us-west-2.amazonaws.com/videos/flower_video_looped.mp4',
+  'https://synergy-assets-11412.s3.us-west-2.amazonaws.com/videos/fire_looped.mp4',
+  'https://synergy-assets-11412.s3.us-west-2.amazonaws.com/videos/water_looped.mp4',
+  'https://synergy-assets-11412.s3.us-west-2.amazonaws.com/videos/flower_video.mov',
+  'https://synergy-assets-11412.s3.us-west-2.amazonaws.com/videos/fire.mov',
+];
+
+export function preloadAssets(): void {
+  modelFiles.forEach((file) => {
+    try {
+      useGLTF.preload(getModelUrl(file));
+    } catch (err) {
+      console.error('Error preloading model:', err);
+    }
+  });
+
+  videoUrls.forEach((url) => {
+    fetch(url)
+      .catch((err) => {
+        console.error('Error preloading video:', err);
+      });
+  });
+}


### PR DESCRIPTION
## Summary
- preload models and videos from S3
- trigger preload during onboarding

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build --workspace=@synergy/client` *(fails: cannot find module 'react')*