### PR TITLE
Limit number of stored socket events

### DIFF
--- a/packages/client/src/hooks/useSocketEvents.ts
+++ b/packages/client/src/hooks/useSocketEvents.ts
@@ -4,6 +4,7 @@ import { socket } from '../socket';
 export default function useSocketEvents() {
   const [isConnected, setIsConnected] = useState(socket.connected);
   const [fooEvents, setFooEvents] = useState<any[]>([]);
+  const MAX_FOO_EVENTS = 100;
   const [sliderValue, setSliderValue] = useState<number | null>(null);
   const [positions, setPositions] = useState<[number, number][]>([]);
 
@@ -15,7 +16,7 @@ export default function useSocketEvents() {
 
     const handleDisconnect = () => setIsConnected(false);
     const handleFoo = (value: any) =>
-      setFooEvents((prev) => [...prev, value]);
+      setFooEvents(prev => [...prev, value].slice(-MAX_FOO_EVENTS));
     const handleSliderUpdate = (value: number) => setSliderValue(value);
     const handleGridUpdate = (data: [number, number][]) => setPositions(data);
 


### PR DESCRIPTION
## Summary
- bound the stored socket events to 100 entries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*