### PR TITLE
Implement frustum culling for VideoTexture

### DIFF
--- a/packages/client/src/components/VideoTexture.tsx
+++ b/packages/client/src/components/VideoTexture.tsx
@@ -1,5 +1,7 @@
 // VideoTexture.tsx
 import { useVideoTexture } from '@react-three/drei';
+import { useThree, useFrame } from '@react-three/fiber';
+import { useRef, useMemo, useState } from 'react';
 import * as THREE from 'three';
 
 type Props = {
@@ -9,12 +11,7 @@ type Props = {
   scale?: [number, number, number];
 };
 
-export default function VideoTexture({
-  url,
-  position = [0, 0, 0],
-  rotation = [0, 0, 0],
-  scale = [1, 1, 1],
-}: Props) {
+function InnerMaterial({ url }: { url: string }) {
   const texture = useVideoTexture(url, {
     muted: true,
     loop: true,
@@ -28,13 +25,56 @@ export default function VideoTexture({
   texture.colorSpace = THREE.SRGBColorSpace;
 
   return (
-    <mesh position={position} rotation={rotation} scale={scale}>
+    <meshBasicMaterial
+      map={texture}
+      toneMapped={false}
+      side={THREE.DoubleSide}
+    />
+  );
+}
+
+export default function VideoTexture({
+  url,
+  position = [0, 0, 0],
+  rotation = [0, 0, 0],
+  scale = [1, 1, 1],
+}: Props) {
+  const { camera } = useThree();
+  const meshRef = useRef<THREE.Mesh>(null);
+  const [visible, setVisible] = useState(false);
+
+  const frustum = useMemo(() => new THREE.Frustum(), []);
+  const projScreenMatrix = useMemo(() => new THREE.Matrix4(), []);
+
+  useFrame(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+
+    // Update matrices for world position
+    mesh.updateMatrixWorld();
+
+    // Update frustum from the camera
+    projScreenMatrix.multiplyMatrices(
+      camera.projectionMatrix,
+      camera.matrixWorldInverse
+    );
+    frustum.setFromProjectionMatrix(projScreenMatrix);
+
+    if (!mesh.geometry.boundingSphere) {
+      mesh.geometry.computeBoundingSphere();
+    }
+
+    const sphere = mesh.geometry.boundingSphere!.clone();
+    sphere.applyMatrix4(mesh.matrixWorld);
+
+    const isVisible = frustum.intersectsSphere(sphere);
+    if (isVisible !== visible) setVisible(isVisible);
+  });
+
+  return (
+    <mesh ref={meshRef} position={position} rotation={rotation} scale={scale}>
       <planeGeometry args={[16, 9]} />
-      <meshBasicMaterial
-        map={texture}
-        toneMapped={false}
-        side={THREE.DoubleSide}
-      />
+      {visible && <InnerMaterial url={url} />}
     </mesh>
   );
 }


### PR DESCRIPTION
## Summary
- prevent video textures from loading and rendering when off‑screen
- check camera frustum each frame and only mount the video material when visible

## Testing
- `npm run lint --workspace=@synergy/client` *(fails: Cannot find package '@eslint/js')*